### PR TITLE
Added a new setting for CloudFront prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Amazon S3 for Craft CMS
 
+## Unreleased
+
+### Added
+- Added the Cloudfront Path Prefix setting.
+
 ## 1.1.3 - 2019-02-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- Added the Cloudfront Path Prefix setting.
+- Added the CloudFront Path Prefix setting.
 
 ## 1.1.3 - 2019-02-06
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ composer require craftcms/aws-s3
 
 To create a new asset volume for your Amazon S3 bucket, go to Settings → Assets, create a new volume, and set the Volume Type setting to “Amazon S3”.
 
-> **Tip:** The Base URL, Access Key ID, Secret Access Key, Subfolder, and CloudFront Distribution ID settings can be set to environment variables. See [Environmental Configuration](https://docs.craftcms.com/v3/config/environments.html) in the Craft docs to learn more about that.
+> **Tip:** The Base URL, Access Key ID, Secret Access Key, Subfolder, CloudFront Distribution ID, and CloudFront Path Prefix settings can be set to environment variables. See [Environmental Configuration](https://docs.craftcms.com/v3/config/environments.html) in the Craft docs to learn more about that.
 
 ### Overriding the Bucket and Region
 

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -113,7 +113,7 @@ class Volume extends FlysystemVolume
     /**
      * @var string CloudFront Distribution Prefix
      */
-    public $cfDistributionPrefix;
+    public $cfPrefix;
 
     /**
      * @var bool Whether facial detection should be attempted to set the focal point automatically
@@ -257,7 +257,7 @@ class Volume extends FlysystemVolume
                             'Paths' =>
                                 [
                                     'Quantity' => 1,
-                                    'Items' => ['/' . $this->_cfDistributionPrefix() . ltrim($path, '/')]
+                                    'Items' => ['/' . $this->_cfPrefix() . ltrim($path, '/')]
                                 ],
                             'CallerReference' => 'Craft-' . StringHelper::randomString(24)
                         ]
@@ -335,10 +335,10 @@ class Volume extends FlysystemVolume
      *
      * @return string|null
      */
-    private function _cfDistributionPrefix(): string
+    private function _cfPrefix(): string
     {
-        if ($this->cfDistributionPrefix && ($cfDistributionPrefix = rtrim(Craft::parseEnv($this->cfDistributionPrefix), '/')) !== '') {
-            return $cfDistributionPrefix . '/';
+        if ($this->cfPrefix && ($cfPrefix = rtrim(Craft::parseEnv($this->cfPrefix), '/')) !== '') {
+            return $cfPrefix . '/';
         }
         return '';
     }

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -248,7 +248,7 @@ class Volume extends FlysystemVolume
         if (!empty($this->cfDistributionId)) {
             // If there's a CloudFront distribution ID set, invalidate the path.
             $cfClient = $this->_getCloudFrontClient();
-            $cfDistributionPrefix = $this->_cfDistributionPrefix();
+
             try {
                 $cfClient->createInvalidation(
                     [
@@ -257,7 +257,7 @@ class Volume extends FlysystemVolume
                             'Paths' =>
                                 [
                                     'Quantity' => 1,
-                                    'Items' => ['/' . ($cfDistributionPrefix ? $cfDistributionPrefix : "") . ltrim($path, '/')]
+                                    'Items' => ['/' . $this->_cfDistributionPrefix() . ltrim($path, '/')]
                                 ],
                             'CallerReference' => 'Craft-' . StringHelper::randomString(24)
                         ]

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -111,6 +111,11 @@ class Volume extends FlysystemVolume
     public $cfDistributionId;
 
     /**
+     * @var string CloudFront Distribution Prefix
+     */
+    public $cfDistributionPrefix;
+
+    /**
      * @var bool Whether facial detection should be attempted to set the focal point automatically
      */
     public $autoFocalPoint = false;
@@ -243,6 +248,7 @@ class Volume extends FlysystemVolume
         if (!empty($this->cfDistributionId)) {
             // If there's a CloudFront distribution ID set, invalidate the path.
             $cfClient = $this->_getCloudFrontClient();
+            $itemPrefix = trim($this->cfDistributionPrefix??"","/");
 
             try {
                 $cfClient->createInvalidation(
@@ -252,7 +258,7 @@ class Volume extends FlysystemVolume
                             'Paths' =>
                                 [
                                     'Quantity' => 1,
-                                    'Items' => ['/'.ltrim($path, '/')]
+                                    'Items' => ['/' . ($itemPrefix ? $itemPrefix."/":"") . ltrim($path, '/')]
                                 ],
                             'CallerReference' => 'Craft-'.StringHelper::randomString(24)
                         ]

--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -115,8 +115,8 @@
 }) }}
 
 {{ forms.autosuggestField({
-    label: "CloudFront prefix"|t('aws-s3'),
-    instructions: "If you're using CloudFront as CDN for your Assets, and have configured sub folders or custom behaviours, you can specify a prefix below."|t('aws-s3'),
+    label: "CloudFront Distribution Prefix"|t('aws-s3'),
+    instructions: "If you're using CloudFront as CDN for your Assets and have configured subfolders or custom behaviours, you can specify a prefix below."|t('aws-s3'),
     id: 'cfDistributionPrefix',
     class: 'ltr',
     name: 'cfDistributionPrefix',

--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -114,4 +114,16 @@
     required: false
 }) }}
 
+{{ forms.autosuggestField({
+    label: "CloudFront prefix"|t('aws-s3'),
+    instructions: "If you're using CloudFront as CDN for your Assets, and have configured sub folders or custom behaviours, you can specify a prefix below."|t('aws-s3'),
+    id: 'cfDistributionPrefix',
+    class: 'ltr',
+    name: 'cfDistributionPrefix',
+    suggestEnvVars: true,
+    value: volume.cfDistributionPrefix,
+    errors: volume.getErrors('cfDistributionPrefix'),
+    required: false
+}) }}
+
 {% do view.registerAssetBundle("craft\\awss3\\AwsS3Bundle") %}

--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -114,14 +114,14 @@
 }) }}
 
 {{ forms.autosuggestField({
-    label: "CloudFront Distribution Prefix"|t('aws-s3'),
+    label: "CloudFront Path Prefix"|t('aws-s3'),
     instructions: "If you’re using CloudFront as CDN for your assets and have configured subfolders or custom behaviors, enter the path prefix Craft should use when invalidating files."|t('aws-s3'),
-    id: 'cfDistributionPrefix',
+    id: 'cfPrefix',
     class: 'ltr',
-    name: 'cfDistributionPrefix',
+    name: 'cfPrefix',
     suggestEnvVars: true,
-    value: volume.cfDistributionPrefix,
-    errors: volume.getErrors('cfDistributionPrefix')
+    value: volume.cfPrefix,
+    errors: volume.getErrors('cfPrefix')
 }) }}
 
 {% do view.registerAssetBundle("craft\\awss3\\AwsS3Bundle") %}

--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -104,26 +104,24 @@
 
 {{ forms.autosuggestField({
     label: "CloudFront Distribution ID"|t('aws-s3'),
-    instructions: "If you're using CloudFront as CDN for your Assets, enter the distribution ID here so Assets can purge the files from CDN."|t('aws-s3'),
+    instructions: "If you’re using CloudFront as CDN for your assets, enter the distribution ID here so Assets can purge the files from CDN."|t('aws-s3'),
     id: 'cfDistributionId',
     class: 'ltr',
     name: 'cfDistributionId',
     suggestEnvVars: true,
     value: volume.cfDistributionId,
-    errors: volume.getErrors('cfDistributionId'),
-    required: false
+    errors: volume.getErrors('cfDistributionId')
 }) }}
 
 {{ forms.autosuggestField({
     label: "CloudFront Distribution Prefix"|t('aws-s3'),
-    instructions: "If you're using CloudFront as CDN for your Assets and have configured subfolders or custom behaviours, you can specify a prefix below."|t('aws-s3'),
+    instructions: "If you’re using CloudFront as CDN for your assets and have configured subfolders or custom behaviors, enter the path prefix Craft should use when invalidating files."|t('aws-s3'),
     id: 'cfDistributionPrefix',
     class: 'ltr',
     name: 'cfDistributionPrefix',
     suggestEnvVars: true,
     value: volume.cfDistributionPrefix,
-    errors: volume.getErrors('cfDistributionPrefix'),
-    required: false
+    errors: volume.getErrors('cfDistributionPrefix')
 }) }}
 
 {% do view.registerAssetBundle("craft\\awss3\\AwsS3Bundle") %}


### PR DESCRIPTION
This allows you to set up a prefix for the invalidation path which is sent to Cloudfront.

This addresses two issues

1. If you configure your volume to use a subfolder via the plugin settings, the path which gets invalidated on Cloudfront does not take this in to account. 

2. Because Cloudfront allows custom behaviours, and mapping of resources via custom paths, eg: you could set up your volume to use an S3 bucket root, but be available from a custom path -  cloudfront.net/some-custom-path/craft/volumes/s3-root. We need a way to tell Cloudfront what the path looks like on the CDN.

Tested an working well :)

Thanks,
Sam