### PR TITLE
Set the cache duration based on the expiration of the returned creden…

### DIFF
--- a/src/Volume.php
+++ b/src/Volume.php
@@ -450,7 +450,9 @@ class Volume extends FlysystemVolume
                 $stsClient = new StsClient($config);
                 $result = $stsClient->getSessionToken(['DurationSeconds' => static::CACHE_DURATION_SECONDS]);
                 $credentials = $stsClient->createCredentials($result);
-                Craft::$app->cache->set($tokenKey, $credentials->serialize(), static::CACHE_DURATION_SECONDS);
+                $cacheDuration = $credentials->getExpiration() - time();
+                $cacheDuration = $cacheDuration > 0 ?: static::CACHE_DURATION_SECONDS;
+                Craft::$app->cache->set($tokenKey, $credentials->serialize(), $cacheDuration);
             }
 
             // TODO Add support for different credential supply methods


### PR DESCRIPTION
Instead of just assuming that AWS is going to give us the credentials duration we ask (even though they should, based on [the documentation](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sts-2011-06-15.html#getsessiontoken) ), instead derive the cache duration from the returned credentials

Signed-off-by: Andrew Welch <andrew@nystudio107.com>