### PR TITLE
add switch to remove subfolder from Base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Amazon S3 for Craft CMS
 
+## Unreleased
+
+### Added
+- Added the `addSubfolderToRootUrl` setting which defaults to true and changes the behavaior of wether adding the subfolder to the Base URL or not.
+
 ## 1.2.7 - 2020-01-09
 
 ### Fixed

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -132,6 +132,11 @@ class Volume extends FlysystemVolume
      */
     public $autoFocalPoint = false;
 
+    /**
+     * @var bool Whether the specified sub folder shoul be added to the root URL
+     */
+    public $addSubfolderToRootUrl = true;
+
     // Public Methods
     // =========================================================================
 
@@ -245,7 +250,9 @@ class Volume extends FlysystemVolume
     public function getRootUrl()
     {
         if (($rootUrl = parent::getRootUrl()) !== false) {
-            $rootUrl .= $this->_subfolder();
+            if ($this->addSubfolderToRootUrl) {
+                $rootUrl .= $this->_subfolder();
+            }
         }
         return $rootUrl;
     }

--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -98,6 +98,13 @@
 }) }}
 
 {{ forms.lightswitchField({
+    label: "Add the subfolder to the Base URL?"|t('aws-s3'),
+    instructions: "Turn this on if you want to add the specified subfolder to the Base URL."|t('aws-s3'),
+    name: 'addSubfolderToRootUrl',
+    on: volume.addSubfolderToRootUrl,
+}) }}
+
+{{ forms.lightswitchField({
     label: "Make Uploads Public"|t('aws-s3'),
     instructions: "Sets the ACL for uploaded objects.",
     id: 'makeUploadsPublic',


### PR DESCRIPTION
There are situations where the subfolder should not be appended to the Base URL. An example is when you want to store the files in a subfolder in the bucket, but part of the path is already covered by the Origin Path and the other part by the Behavior.

FOR EXAMPLE:

Base URL: http://hostname/assets
Subfolder: "customer/assets"
Origin-Path of S3-Origin in CF Distribution: "customer"
Behavior in CF Distribution with S3-Origin: "assets"

Currently, the following URL is generated for a file named "image.jpg" for this configuration:

http://hostname/assets/customer/assets/image.jpg

What is desired, however:

http://hostname/assets/image.jpg

This is because "customer" is added by the Origin Path and must not be listed again in the URL. "assets" must appear in the Base URL because it triggers the Behavior.

Therefore, adding the subfolder to the Base URL should be optional. With this PR a corresponding switch is added to the volume settings, with which you can switch off the default behavior.