### PR TITLE
Fix bug where focal point detection will fail if the volume subfolder…

### DIFF
--- a/src/Volume.php
+++ b/src/Volume.php
@@ -387,7 +387,7 @@ class Volume extends FlysystemVolume
         $params = [
             'Image' => [
                 'S3Object' => [
-                    'Name' => $filePath,
+                    'Name' => Craft::parseEnv($filePath),
                     'Bucket' => Craft::parseEnv($this->bucket),
                 ],
             ],


### PR DESCRIPTION
… setting contains an alias.

It fails because the alias is passed unexpanded to AWS as part of the object name.

Example error log:
2020-05-26 21:12:57 [-][1][-][error][craft\controllers\AssetsController::actionUpload] An error occurred when saving an asset: Error executing "DetectFaces" on "https://rekognition.us-east-1.amazonaws.com"; AWS HTTP error: Client error: `POST https://rekognition.us-east-1.amazonaws.com` resulted in a `400 Bad Request` response:
{"__type":"InvalidS3ObjectException","Code":"InvalidS3ObjectException","Logref":"ab2b33db-a156-41c5-8050-fd4e0b1d8c72"," (truncated...)
 InvalidS3ObjectException (client): Unable to get object metadata from S3. Check object key, region and/or access permissions. - {"__type":"InvalidS3ObjectException","Code":"InvalidS3ObjectException","Logref":"ab2b33db-a156-41c5-8050-fd4e0b1d8c72","Message":"Unable to get object metadata from S3. Check object key, region and/or access permissions."}
    in /var/app/vendor/craftcms/cms/src/controllers/AssetsController.php:375
    in /var/app/vendor/craftcms/cms/src/web/Controller.php:178
    in /var/app/vendor/craftcms/cms/src/web/Application.php:291