### PR TITLE
fix typo in s3 url builder

### DIFF
--- a/src/resources/js/editVolume.js
+++ b/src/resources/js/editVolume.js
@@ -103,7 +103,7 @@ $(document).ready(function() {
 
 	var maybeUpdateUrl = function () {
 		if ($hasUrls.val() && $manualBucket.val().length && $manualRegion.val().length) {
-			$volumeUrl.val('https://s3.' + $manualRegion.val() + '.amazonaws/' + $manualBucket.val() + '/');
+			$volumeUrl.val('https://s3.' + $manualRegion.val() + '.amazonaws.com/' + $manualBucket.val() + '/');
 		}
 	};
 


### PR DESCRIPTION
### Description
The URL builder contains a typo in the amazon domain name (.com is omitted). 


### Related issues

https://github.com/craftcms/aws-s3/issues/109