### PR TITLE
feat: implement IAM authentication with assumeRoleWithWebIdentityCredentialProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,7 @@ This plugin can use the AWS Rekognition service to detect faces in an image and 
 :warning: ️Using this will incur extra cost for each upload
 
 :warning: ️Using this requires the <code>rekognition:DetectFaces</code> action to be allowed.
+
+### Assuming Role with OIDC
+
+This plugin also has the ability to assume a role provided to the runtime with the `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` environment variables. If you provide no credentials to AWS and these environment variables exist, then the plugin will attempt to create a connection to AWS using the `CredentialProvider::assumeRoleWithWebIdentityCredentialProvider`. This is the ideal way to allow fine-grained access control for hosting CraftCMS in Kubernetes (for example). See [the IAM documentation on AWS for more details](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html).


### PR DESCRIPTION
Hi all, I've put together a pull request for your consideration. 

### Description

Authentication with IAM roles in this plugin is limited to two methods: Hard-coding access id and secret, or EC2 metadata query (for instance roles). The change proposed here will allow the plugin to use a third methodology: `assumeRoleWithWebIdentityCredentialProvider`. The purpose of this change is to enable a Kubernetes pod-level access control to our selected S3 bucket without having to hard-code any credentials. This functionality is discussed in depth here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html

Assuming the Pod ServiceAccount has been configured correctly, the Pod will have two environment variables injected: `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`. When this plugin creates the S3 client via the SDK, we can check if those values exist (after checking for hard-coded access tokens), and use those values to assume our role within the S3 Client.

I am not a PHP developer, so I am sure there is a more idiomatic way of implementing the required logic - but it is just a simple conditional to check the environment variables and create the S3 Client. Most of the code is straight from the developer documentation: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#assume-role-with-web-identity-provider. 

I have tested this functionality on my own AWS deployment and can confirm that it works, however I don't have any further kind of testing capability. I intend to deploy my fork of this plugin to production until this change has been merged (if it does, that is...). Feel free to let me know if there is anything I can do to help this get merged!

Cheers!

