### PR TITLE
Fix web identity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Amazon S3 for Craft CMS
 
+## 1.2.13 - 2021-07-29
+### Fixed
+- Fixed a regression introduced by [#118](https://github.com/craftcms/aws-s3/pull/118) that would prevent credential-less EC2 access from working. ([#120](https://github.com/craftcms/aws-s3/issues/120))
+
 ## 1.2.12 - 2021-07-20
 
 ### Added

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -431,7 +431,7 @@ class Volume extends FlysystemVolume
 
         if (empty($keyId) || empty($secret)) {
             // Check for predefined access
-            if (!empty(Craft::parseEnv("AWS_WEB_IDENTITY_TOKEN_FILE")) && !empty(Craft::parseEnv("AWS_ROLE_ARN"))) {
+            if (App::env('AWS_WEB_IDENTITY_TOKEN_FILE') && App::env('AWS_ROLE_ARN')) {
                 // Check if anything is defined for a web identity provider (see: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#assume-role-with-web-identity-provider)
                 $provider = CredentialProvider::assumeRoleWithWebIdentityCredentialProvider();
                 $provider = CredentialProvider::memoize($provider);


### PR DESCRIPTION
### Description
https://github.com/craftcms/aws-s3/commit/71e1b3928b4de7c995cdce424c43ac1a773fd880 introduced a regression that would break auth for anyone using credential-less EC2 access.

As-is, credential-less access won't work for anyone (except those using `AWS_WEB_IDENTITY_TOKEN_FILE`).

`Craft::parseEnv` expects the `$` to be included to parse env vars. Since we're not concerned with alias parsing or normalization, it seems like `App::env` is a better choice here.

### Related issues
- https://github.com/craftcms/aws-s3/issues/120
- https://github.com/craftcms/aws-s3/pull/118