### PR TITLE
Add IAM support for ECS tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,7 @@ This plugin can use the AWS Rekognition service to detect faces in an image and 
 ### Assuming Role with OIDC
 
 This plugin also has the ability to assume a role provided to the runtime with the `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` environment variables. If you provide no credentials to AWS and these environment variables exist, then the plugin will attempt to create a connection to AWS using the `CredentialProvider::assumeRoleWithWebIdentityCredentialProvider`. This is the ideal way to allow fine-grained access control for hosting CraftCMS in Kubernetes (for example). See [the IAM documentation on AWS for more details](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html).
+
+### Tasks running in ECS
+
+This pluging is compatible with IAM roles for ECS tasks and will automatically use the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable. For more informations on task IAM roles please refer to [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -437,6 +437,13 @@ class Volume extends FlysystemVolume
                 $provider = CredentialProvider::memoize($provider);
                 $config['credentials'] = $provider;
             }
+            // Check if running on ECS
+            if (App::env('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI')) {
+                // Check if anything is defined for an ecsCredentials provider
+                $provider = CredentialProvider::ecsCredentials();
+                $provider = CredentialProvider::memoize($provider);
+                $config['credentials'] = $provider;
+            }
             // If that didn't happen, assume we're running on EC2 and we have an IAM role assigned so no action required.
         } else {
             $tokenKey = static::CACHE_KEY_PREFIX . md5($keyId . $secret);


### PR DESCRIPTION
### Description

This PR adds support for https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html.
It's mostly based on https://github.com/craftcms/aws-s3/pull/118 and https://github.com/craftcms/aws-s3/pull/121/files

I used https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html for the configuration.

Note: I'm not a PHP developer 😅 so if there is anything to change, let me know!
