### PR TITLE
Fixes “fs” shorthand in field instruction

### DIFF
--- a/src/templates/fsSettings.html
+++ b/src/templates/fsSettings.html
@@ -87,7 +87,7 @@
 
 {{ forms.autosuggestField({
     label: "Subfolder"|t('aws-s3'),
-    instructions: "If you want to use a bucket’s subfolder as a fs, specify the path to use here."|t('aws-s3'),
+    instructions: "If you want to use a bucket’s subfolder as a filesystem, specify the path to use here."|t('aws-s3'),
     id: 'subfolder',
     class: 'ltr',
     name: 'subfolder',


### PR DESCRIPTION
### Description

The user-facing field instructions for an S3 bucket subfolder currently say “fs” instead of “filesystem.”