### PR TITLE
correctly calculate the cacheDuration for AWS credentials

### DIFF
--- a/src/Volume.php
+++ b/src/Volume.php
@@ -459,7 +459,7 @@ class Volume extends FlysystemVolume
                 $result = $stsClient->getSessionToken(['DurationSeconds' => static::CACHE_DURATION_SECONDS]);
                 $credentials = $stsClient->createCredentials($result);
                 $cacheDuration = $credentials->getExpiration() - time();
-                $cacheDuration = $cacheDuration > 0 ?: static::CACHE_DURATION_SECONDS;
+                $cacheDuration = $cacheDuration > 0 ? $cacheDuration : static::CACHE_DURATION_SECONDS;
                 Craft::$app->cache->set($tokenKey, $credentials->serialize(), $cacheDuration);
             }
 


### PR DESCRIPTION
fix: correctly cache the cacheDuration for AWS credentials

$cacheDuration > 0 ?: static::CACHE_DURATION_SECONDS will result in `1`, 
which is not what we want out of this ternary statement.

By replacing the `or ternary` with a regular ternary we get the results that we want `3600`.

### Description



### Related issues

