### PR TITLE
Virtual host URL format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Amazon S3 for Craft CMS
 
+## Unreleased
+
+- Buckets that don’t include a `.` in their name now use the new virtual host URL format by default. ([#128](https://github.com/craftcms/aws-s3/issues/128))
+
 ## 1.3.0 - 2021-10-21
 
 ### Changed

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -241,7 +241,7 @@ class Volume extends FlysystemVolume
                 continue;
             }
 
-            if (str_contains($bucket['Name'], '.')) {
+            if (StringHelper::contains($bucket['Name'], '.')) {
                 $urlPrefix = 'https://s3.' . $region . '.amazonaws.com/' . $bucket['Name'] . '/';
             } else {
                 $urlPrefix = 'https://' . $bucket['Name'] . '.s3.amazonaws.com/';

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -241,9 +241,15 @@ class Volume extends FlysystemVolume
                 continue;
             }
 
+            if (str_contains($bucket['Name'], '.')) {
+                $urlPrefix = 'https://s3.' . $region . '.amazonaws.com/' . $bucket['Name'] . '/';
+            } else {
+                $urlPrefix = 'https://' . $bucket['Name'] . '.s3.amazonaws.com/';
+            }
+
             $bucketList[] = [
                 'bucket' => $bucket['Name'],
-                'urlPrefix' => 'https://s3.' . $region . '.amazonaws.com/' . $bucket['Name'] . '/',
+                'urlPrefix' => $urlPrefix,
                 'region' => $region,
             ];
         }


### PR DESCRIPTION
Adjusts the URL format to use the new virtual host format if your bucket name doesn't include a ".".

Fixes #128

