### PR TITLE
✨ allow to set the  header to `AES256` when uploading files to S3

### DIFF
--- a/src/templates/fsSettings.html
+++ b/src/templates/fsSettings.html
@@ -176,4 +176,23 @@
     errors: fs.getErrors('cfPrefix')
 }) }}
 
+{% set sseInput %}
+    {{ forms.select({
+        name: 'serverSideEncryption',
+        options: [
+            { label: 'None', value: '' },
+            { label: 'S3 Managed', value: 'S3_MANAGED' }
+        ],
+        value: fs.serverSideEncryption
+    }) }}
+{% endset %}
+
+{{ forms.field({
+    label: "Server-side encryption"|t('aws-s3'),
+    id: 'serverSideEncryption',
+    instructions: "Specifies which type of server-side encryption the object must be stored with in S3.",
+    required: false,
+    errors: fs.getErrors('serverSideEncryption'),
+}, sseInput) }}
+
 {% do view.registerAssetBundle("craft\\awss3\\AwsS3Bundle") %}


### PR DESCRIPTION
### Description
Allows to specify `AES256` (the default S3 encryption) as the server-side encryption method for storing objects in S3.

### Considerations
Implemented this as this has become a common security practice to prevent the upload of unencrypted objects to S3.

[📙 How to prevent uploads of unencrypted objects to amazon s3](https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/)

Does not add support for `aws:kms` encryption.

### Related issues
[Ability to use server side encryption #154](https://github.com/craftcms/aws-s3/issues/154)
