### PR TITLE
Send SSE AES256 header by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Amazon S3 for Craft CMS
 
+## 2.2.0 - 2024-03-13
+
+- Uploads will now include the `x-amz-server-side-encryption=AES256` header for parity with S3 defaults. (Thanks @drieshooghe!) [#172](https://github.com/craftcms/aws-s3/pull/172)
+
 ## 2.1.0 - 2024-03-11
 
 - Added Craft 5 compatibility.

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -281,7 +281,23 @@ class Fs extends FlysystemFs
     protected function createAdapter(): FilesystemAdapter
     {
         $client = static::client($this->_getConfigArray(), $this->_getCredentials());
-        return new AwsS3V3Adapter($client, Craft::parseEnv($this->bucket), $this->_subfolder(), new PortableVisibilityConverter($this->visibility()), null, [], false);
+        $options = [
+
+            // This is the S3 default for all objects, but explicitly
+            // sending the header allows for bucket policies that require it.
+            // @see https://github.com/craftcms/aws-s3/pull/172
+            'ServerSideEncryption' => 'AES256',
+        ];
+
+        return new AwsS3V3Adapter(
+            $client,
+            App::parseEnv($this->bucket),
+            $this->_subfolder(),
+            new PortableVisibilityConverter($this->visibility()),
+            null,
+            $options,
+            false,
+        );
     }
 
     /**


### PR DESCRIPTION
### Description
Sets the AES256 `ServerSideEncryption` header by default to align with AWS S3's default.

Since this happens anyway on S3, this doesn't change behavior, but allows for bucket policies that require encryption.

See https://github.com/craftcms/aws-s3/pull/172