### PR TITLE
invalidate original asset on replace

### DIFF
--- a/src/Fs.php
+++ b/src/Fs.php
@@ -343,6 +343,26 @@ class Fs extends FlysystemFs
     /**
      * @inheritdoc
      */
+    public function write(string $path, string $contents, array $config = []): void
+    {
+        parent::write($path, $contents, $config);
+
+        $this->invalidateCdnPath($path);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function writeFileFromStream(string $path, $stream, array $config = []): void
+    {
+        parent::writeFileFromStream($path, $stream, $config);
+
+        $this->invalidateCdnPath($path);
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function invalidateCdnPath(string $path): bool
     {
         if (!empty($this->cfDistributionId)) {

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -343,26 +343,6 @@ class Fs extends FlysystemFs
     /**
      * @inheritdoc
      */
-    public function write(string $path, string $contents, array $config = []): void
-    {
-        parent::write($path, $contents, $config);
-
-        $this->invalidateCdnPath($path);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function writeFileFromStream(string $path, $stream, array $config = []): void
-    {
-        parent::writeFileFromStream($path, $stream, $config);
-
-        $this->invalidateCdnPath($path);
-    }
-
-    /**
-     * @inheritdoc
-     */
     protected function invalidateCdnPath(string $path): bool
     {
         if (!empty($this->cfDistributionId)) {

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -343,7 +343,7 @@ class Fs extends FlysystemFs
     /**
      * @inheritdoc
      */
-    protected function invalidateCdnPath(string $path): bool
+    public function invalidateCdnPath(string $path): bool
     {
         if (!empty($this->cfDistributionId)) {
             if (empty($this->pathsToInvalidate)) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,6 +11,8 @@ use craft\base\Element;
 use craft\elements\Asset;
 use craft\events\ModelEvent;
 use craft\events\RegisterComponentTypesEvent;
+use craft\events\ReplaceAssetEvent;
+use craft\services\Assets;
 use craft\services\Fs as FsService;
 use yii\base\Event;
 
@@ -42,6 +44,23 @@ class Plugin extends \craft\base\Plugin
         Event::on(FsService::class, FsService::EVENT_REGISTER_FILESYSTEM_TYPES, function(RegisterComponentTypesEvent $event) {
             $event->types[] = Fs::class;
         });
+
+        Event::on(
+            Assets::class,
+            Assets::EVENT_BEFORE_REPLACE_ASSET,
+            function (ReplaceAssetEvent $event) {
+                $asset = $event->asset;
+                $oldFilename = $asset->getFilename();
+                $newFilename = $event->filename;
+
+                // when replacing asset with another one with the same filename, invalidate the cdn path for the original file too
+                // see https://github.com/craftcms/aws-s3/issues/184 for details
+                if ($oldFilename === $newFilename) {
+                    $fs = $asset->getVolume()->getFs();
+                    $fs->invalidateCdnPath($asset->getPath());
+                }
+            }
+        );
 
         Event::on(Asset::class, Element::EVENT_AFTER_SAVE, function(ModelEvent $event) {
             if (!$event->isNew) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -48,7 +48,7 @@ class Plugin extends \craft\base\Plugin
         Event::on(
             Assets::class,
             Assets::EVENT_BEFORE_REPLACE_ASSET,
-            function (ReplaceAssetEvent $event) {
+            function(ReplaceAssetEvent $event) {
                 $asset = $event->asset;
                 $oldFilename = $asset->getFilename();
                 $newFilename = $event->filename;
@@ -56,6 +56,7 @@ class Plugin extends \craft\base\Plugin
                 // when replacing asset with another one with the same filename, invalidate the cdn path for the original file too
                 // see https://github.com/craftcms/aws-s3/issues/184 for details
                 if ($oldFilename === $newFilename) {
+                    /** @var Fs $fs */
                     $fs = $asset->getVolume()->getFs();
                     $fs->invalidateCdnPath($asset->getPath());
                 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -50,14 +50,18 @@ class Plugin extends \craft\base\Plugin
             Assets::EVENT_BEFORE_REPLACE_ASSET,
             function(ReplaceAssetEvent $event) {
                 $asset = $event->asset;
+                $fs = $asset->getVolume()->getFs();
+
+                if (!$fs instanceof Fs) {
+                    return;
+                }
+
                 $oldFilename = $asset->getFilename();
                 $newFilename = $event->filename;
 
                 // when replacing asset with another one with the same filename, invalidate the cdn path for the original file too
                 // see https://github.com/craftcms/aws-s3/issues/184 for details
                 if ($oldFilename === $newFilename) {
-                    /** @var Fs $fs */
-                    $fs = $asset->getVolume()->getFs();
                     $fs->invalidateCdnPath($asset->getPath());
                 }
             }


### PR DESCRIPTION
### Description

Call `invalidateCdnPath()` when replacing asset so that it can be invalidated in CloudFront when a file gets replaced with another one with the same name.

### Related issues
#184 
