### PR TITLE
Minio support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Amazon S3 for Craft CMS
 
+## Unreleased
+
+- When `AWS_ENDPOINT_URL_S3` is set, AWS S3 filesystems now skip STS `GetSessionToken` and use static credentials directly, improving compatibility with S3-compatible services like MinIO.
+
 ## 2.2.4 - 2026-01-14
 
 - Fixed a PHP error that could occur in some environments. ([#183](https://github.com/craftcms/aws-s3/issues/183))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- When `AWS_ENDPOINT_URL_S3` is set, AWS S3 filesystems now skip STS `GetSessionToken` and use static credentials directly, improving compatibility with S3-compatible services like MinIO.
+- Added explicit STS control for S3-compatible providers: endpoint mode still defaults to direct credentials (for MinIO compatibility), and you can set `AWS_S3_USE_STS=true` for providers that support STS (for example, Wasabi).
 
 ## 2.2.4 - 2026-01-14
 

--- a/README.md
+++ b/README.md
@@ -118,4 +118,8 @@ This plugin is compatible with IAM roles for ECS tasks and will automatically us
 
 ### S3-Compatible Endpoints
 
-If `AWS_ENDPOINT_URL_S3` is set, the plugin will use the configured Access Key ID and Secret Access Key directly, and will not attempt to call AWS STS `GetSessionToken`. This improves compatibility with S3-compatible services like MinIO.
+If `AWS_ENDPOINT_URL_S3` is set, the plugin can be used with S3-compatible services like MinIO and Wasabi.
+
+By default, when `AWS_ENDPOINT_URL_S3` is set, the plugin uses the configured Access Key ID and Secret Access Key directly (without requesting AWS STS `GetSessionToken`) for compatibility with services like MinIO.
+
+If your provider supports STS (for example, Wasabi), set `AWS_S3_USE_STS=true` to request temporary credentials via STS.

--- a/README.md
+++ b/README.md
@@ -115,3 +115,7 @@ This plugin also has the ability to assume a role provided to the runtime with t
 ### Tasks running in ECS
 
 This plugin is compatible with IAM roles for ECS tasks and will automatically use the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable, if it’s available. See [the IAM Roles for Tasks documentation on AWS for more details](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).
+
+### S3-Compatible Endpoints
+
+If `AWS_ENDPOINT_URL_S3` is set, the plugin will use the configured Access Key ID and Secret Access Key directly, and will not attempt to call AWS STS `GetSessionToken`. This improves compatibility with S3-compatible services like MinIO.

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -475,8 +475,8 @@ class Fs extends FlysystemFs
         } else {
             $credentials = new Credentials($keyId, $secret);
 
-            // Custom S3-compatible endpoints (for example, MinIO) typically do not support AWS STS GetSessionToken.
-            if (!empty(App::env('AWS_ENDPOINT_URL_S3'))) {
+            // Some S3-compatible providers (for example, MinIO) do not support AWS STS GetSessionToken.
+            if (!static::shouldUseStsSessionToken()) {
                 $config['credentials'] = $credentials;
             } else {
                 $tokenKey = static::CACHE_KEY_PREFIX . md5($keyId . $secret);
@@ -500,6 +500,20 @@ class Fs extends FlysystemFs
         }
 
         return $config;
+    }
+
+    /**
+     * Returns whether the plugin should request temporary credentials from AWS STS.
+     */
+    private static function shouldUseStsSessionToken(): bool
+    {
+        $useSts = App::env('AWS_S3_USE_STS');
+
+        if ($useSts !== null && $useSts !== '') {
+            return filter_var($useSts, FILTER_VALIDATE_BOOL) === true;
+        }
+
+        return empty(App::env('AWS_ENDPOINT_URL_S3'));
     }
 
     // Private Methods

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -13,7 +13,7 @@ use Aws\CloudFront\CloudFrontClient;
 use Aws\CloudFront\Exception\CloudFrontException;
 use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
-use Aws\Handler\Guzzle\GuzzleHandler;
+use Aws\Handler\GuzzleV6\GuzzleHandler;
 use Aws\Rekognition\RekognitionClient;
 use Aws\S3\Exception\S3Exception;
 use Aws\Sts\StsClient;

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -473,24 +473,30 @@ class Fs extends FlysystemFs
             }
             // If that didn't happen, assume we're running on EC2 and we have an IAM role assigned so no action required.
         } else {
-            $tokenKey = static::CACHE_KEY_PREFIX . md5($keyId . $secret);
             $credentials = new Credentials($keyId, $secret);
 
-            if (Craft::$app->cache->exists($tokenKey) && !$refreshToken) {
-                $cached = Craft::$app->cache->get($tokenKey);
-                $credentials->unserialize($cached);
-            } else {
+            // Custom S3-compatible endpoints (for example, MinIO) typically do not support AWS STS GetSessionToken.
+            if (!empty(App::env('AWS_ENDPOINT_URL_S3'))) {
                 $config['credentials'] = $credentials;
-                $stsClient = new StsClient($config);
-                $result = $stsClient->getSessionToken(['DurationSeconds' => static::CACHE_DURATION_SECONDS]);
-                $credentials = $stsClient->createCredentials($result);
-                $cacheDuration = $credentials->getExpiration() - time();
-                $cacheDuration = $cacheDuration > 0 ? $cacheDuration : static::CACHE_DURATION_SECONDS;
-                Craft::$app->cache->set($tokenKey, $credentials->serialize(), $cacheDuration);
-            }
+            } else {
+                $tokenKey = static::CACHE_KEY_PREFIX . md5($keyId . $secret);
 
-            // TODO Add support for different credential supply methods
-            $config['credentials'] = $credentials;
+                if (Craft::$app->cache->exists($tokenKey) && !$refreshToken) {
+                    $cached = Craft::$app->cache->get($tokenKey);
+                    $credentials->unserialize($cached);
+                } else {
+                    $config['credentials'] = $credentials;
+                    $stsClient = new StsClient($config);
+                    $result = $stsClient->getSessionToken(['DurationSeconds' => static::CACHE_DURATION_SECONDS]);
+                    $credentials = $stsClient->createCredentials($result);
+                    $cacheDuration = $credentials->getExpiration() - time();
+                    $cacheDuration = $cacheDuration > 0 ? $cacheDuration : static::CACHE_DURATION_SECONDS;
+                    Craft::$app->cache->set($tokenKey, $credentials->serialize(), $cacheDuration);
+                }
+
+                // TODO Add support for different credential supply methods
+                $config['credentials'] = $credentials;
+            }
         }
 
         return $config;


### PR DESCRIPTION
- Document that enabling AWS_ENDPOINT_URL_S3 makes the plugin reuse static credentials without calling STS, improving compatibility with S3-compatible endpoints.
- Update Fs.php to skip the STS GetSessionToken flow and caching when a custom endpoint is configured.
- Log the change in CHANGELOG.md and expand the README guidance for S3-compatible services.