### PR TITLE
Handle ExpiredToken during async S3

### DIFF
--- a/src/S3Client.php
+++ b/src/S3Client.php
@@ -10,6 +10,8 @@ namespace craft\awss3;
 use Aws\CommandInterface;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client as AwsS3Client;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\RejectedPromise;
 
 /**
  * Class S3Client
@@ -52,16 +54,19 @@ class S3Client extends AwsS3Client
     {
         try {
             // Just try to execute
-            return $this->_wrappedClient->executeAsync($command);
+            return $this->_wrappedClient
+                ->executeAsync($command)
+                ->otherwise(function($reason) use ($command) {
+                    if ($reason instanceof S3Exception && $reason->getAwsErrorCode() === 'ExpiredToken') {
+                        return $this->_retryWithFreshCredentials($command);
+                    }
+
+                    return new RejectedPromise($reason);
+                });
         } catch (S3Exception $exception) {
             // Attempt to get new credentials
             if ($exception->getAwsErrorCode() == 'ExpiredToken') {
-                $clientConfig = call_user_func($this->_generateNewConfig);
-                $this->_wrappedClient = new parent($clientConfig);
-
-                // Re-create the command to use the new credentials
-                $newCommand = $this->getCommand($command->getName(), $command->toArray());
-                return $this->_wrappedClient->executeAsync($newCommand);
+                return $this->_retryWithFreshCredentials($command);
             }
 
             throw $exception;
@@ -75,5 +80,25 @@ class S3Client extends AwsS3Client
     {
         // Use the wrapped client which should have the latest credentials.
         return $this->_wrappedClient->getCommand($name, $args);
+    }
+
+    /**
+     * Attempts a single retry with newly generated credentials.
+     */
+    private function _retryWithFreshCredentials(CommandInterface $command): PromiseInterface
+    {
+        if (!isset($this->_generateNewConfig) || !is_callable($this->_generateNewConfig)) {
+            return new RejectedPromise(new S3Exception(
+                'AWS credentials expired and no credential refresh callback is configured.',
+                $command
+            ));
+        }
+
+        $clientConfig = call_user_func($this->_generateNewConfig);
+        $this->_wrappedClient = new parent($clientConfig);
+
+        // Re-create the command to use the refreshed client config and credentials.
+        $newCommand = $this->getCommand($command->getName(), $command->toArray());
+        return $this->_wrappedClient->executeAsync($newCommand);
     }
 }

--- a/src/S3Client.php
+++ b/src/S3Client.php
@@ -22,9 +22,9 @@ use GuzzleHttp\Promise\RejectedPromise;
 class S3Client extends AwsS3Client
 {
     /**
-     * @var callable callback for generating new config, including new credentials.
+     * @var (callable(): array)|null callback for generating new config, including new credentials.
      */
-    private $_generateNewConfig;
+    private $_generateNewConfig = null;
 
     /**
      * @var AwsS3Client the wrapped AWS client to use for all requests
@@ -36,7 +36,7 @@ class S3Client extends AwsS3Client
      */
     public function __construct(array $args)
     {
-        if (!empty($args['generateNewConfig'])) {
+        if (!empty($args['generateNewConfig']) && is_callable($args['generateNewConfig'])) {
             $this->_generateNewConfig = $args['generateNewConfig'];
             unset($args['generateNewConfig']);
         }
@@ -87,7 +87,7 @@ class S3Client extends AwsS3Client
      */
     private function _retryWithFreshCredentials(CommandInterface $command): PromiseInterface
     {
-        if (!isset($this->_generateNewConfig) || !is_callable($this->_generateNewConfig)) {
+        if ($this->_generateNewConfig === null) {
             return new RejectedPromise(new S3Exception(
                 'AWS credentials expired and no credential refresh callback is configured.',
                 $command


### PR DESCRIPTION
### Description

executeAsync() now handles ExpiredToken on async promise rejection, not only in synchronous catch.

### Related issues

Closes #182 