### PR TITLE
Fix CDN path invalidation for replaced assets with the same filename

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -59,10 +59,10 @@ class Plugin extends \craft\base\Plugin
                 $oldFilename = $asset->getFilename();
                 $newFilename = $event->filename;
 
-                // when replacing asset with another one with the same filename, invalidate the cdn path for the original file too
-                // see https://github.com/craftcms/aws-s3/issues/184 for details
+                // when replacing an asset with another one with the same filename, invalidate the CDN path for the original file too
+                // see https://github.com/craftcms/aws-s3/issues/184 and https://github.com/craftcms/aws-s3/issues/195 for details
                 if ($oldFilename === $newFilename) {
-                    $folderPath = trim($asset->getFolder()->path, '/');
+                    $folderPath = trim($asset->getFolder()?->path, '/');
                     $oldPath = $folderPath !== ''
                         ? $folderPath . '/' . $oldFilename
                         : $oldFilename;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -62,7 +62,7 @@ class Plugin extends \craft\base\Plugin
                 // when replacing an asset with another one with the same filename, invalidate the CDN path for the original file too
                 // see https://github.com/craftcms/aws-s3/issues/184 and https://github.com/craftcms/aws-s3/issues/195 for details
                 if ($oldFilename === $newFilename) {
-                    $folderPath = trim($asset->getFolder()?->path, '/');
+                    $folderPath = trim($asset->getFolder()->path, '/');
                     $oldPath = $folderPath !== ''
                         ? $folderPath . '/' . $oldFilename
                         : $oldFilename;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -62,7 +62,12 @@ class Plugin extends \craft\base\Plugin
                 // when replacing asset with another one with the same filename, invalidate the cdn path for the original file too
                 // see https://github.com/craftcms/aws-s3/issues/184 for details
                 if ($oldFilename === $newFilename) {
-                    $fs->invalidateCdnPath($asset->getPath());
+                    $folderPath = trim($asset->getFolder()->path, '/');
+                    $oldPath = $folderPath !== ''
+                        ? $folderPath . '/' . $oldFilename
+                        : $oldFilename;
+
+                    $fs->invalidateCdnPath($oldPath);
                 }
             }
         );


### PR DESCRIPTION
### Description

This pull request makes a targeted fix to the CDN invalidation logic when replacing an asset with another asset that has the same filename. The update ensures that the correct path is invalidated in the CDN.

CDN invalidation fix:

* Updated the logic to construct the correct `oldPath` by including the folder path when invalidating the CDN path for replaced assets with the same filename. This ensures the original file's CDN path is properly invalidated.

### Related issues

https://github.com/craftcms/aws-s3/issues/195