### PR TITLE
v6 with adapter - compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin provides an [Amazon S3](https://aws.amazon.com/s3/) integration for 
 
 ## Requirements
 
-This plugin requires Craft CMS 4.0.0+ or 5.0.0+.
+This plugin requires Craft CMS 4.0.0+ or 5.0.0+ or 6.0.0-alpha.1+ with the `craftcms/yii2-adapter` package.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
     "email": "support@craftcms.com",
     "issues": "https://github.com/craftcms/aws-s3/issues?state=open",
     "source": "https://github.com/craftcms/aws-s3",
-    "docs": "https://github.com/craftcms/aws-s3/blob/master/README.md",
-    "rss": "https://github.com/craftcms/aws-s3/commits/master.atom"
+    "docs": "https://github.com/craftcms/aws-s3/blob/2.x/README.md",
+    "rss": "https://github.com/craftcms/aws-s3/commits/2.x.atom"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
     "php": "^8.1.0",
-    "craftcms/cms": "^4.0.0-beta.1|^5.0.0-beta.1",
+    "craftcms/cms": "^4.0.0-beta.1|^5.0.0-beta.1|^6.0.0-alpha.1",
     "craftcms/flysystem": "^1.0.0-beta.2|^2.0.0",
     "league/flysystem-aws-s3-v3": "^3.0.0"
   },
@@ -50,7 +50,7 @@
   "extra": {
     "name": "Amazon S3",
     "handle": "aws-s3",
-    "documentationUrl": "https://github.com/craftcms/aws-s3/blob/master/README.md"
+    "documentationUrl": "https://github.com/craftcms/aws-s3/blob/2.x/README.md"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
### Description
Makes the plugin compatible with cms v6 when using the `yii2-adapter` package.

WIP; more changes might be needed

### Related issues

