### PR TITLE
Fix _cfPrefix() TypeError when cfPrefix env var resolves to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Amazon S3 for Craft CMS
 
+## Unreleased
+
+- Fixed a PHP error that could occur if the CloudFront Path Prefix was set to an environment variable that resolves to an empty string. ([#199](https://github.com/craftcms/aws-s3/issues/199))
+
 ## 2.3.1 - 2026-06-09
 
 - Fixed a bug where CloudFront caches would not get invalidated when uploading an asset with an existing filename to a subfolder. ([#195](https://github.com/craftcms/aws-s3/issues/195))

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -533,7 +533,7 @@ class Fs extends FlysystemFs
      */
     private function _cfPrefix(): string
     {
-        if ($this->cfPrefix && ($cfPrefix = rtrim(Craft::parseEnv($this->cfPrefix), '/')) !== '') {
+        if ($this->cfPrefix && ($cfPrefix = rtrim((string)App::parseEnv($this->cfPrefix), '/')) !== '') {
             return $cfPrefix . '/';
         }
 


### PR DESCRIPTION
Fixes #199

`_cfPrefix()` still passes the result of `parseEnv()` straight into `rtrim()`, which throws a TypeError when the env var resolves to an empty string (Craft ≥ 5.10.2 returns `null` in that case). This applies the same `(string)App::parseEnv()` cast that `_subfolder()` received in 2.2.6 (a16f224) — #189 originally reported both methods, but only `_subfolder()` was patched.

Without this, any filesystem with `cfPrefix` set to an empty env var 500s on every asset upload/replace/delete via `purgeQueuedPaths()` on `EVENT_AFTER_REQUEST`.
